### PR TITLE
Fixed error with burst size

### DIFF
--- a/amqp_rcv_th.c
+++ b/amqp_rcv_th.c
@@ -87,10 +87,10 @@ static void handle_receive(app_data_t *app, pn_event_t *event, int *batch_done) 
                 app->max_q_depth = inuse;
 
             int link_credit = pn_link_credit(l);
-            //pn_link_flow(l, rb_size(app->rbin) - link_credit);
-             if (link_credit < rb_free_size(app->rbin)) {
-                 *batch_done = link_credit;
-                 pn_link_flow(l, rb_free_size(app->rbin) - link_credit);
+            int free_size = rb_free_size(app->rbin);
+            *batch_done = ( free_size == 0 );
+             if (link_credit < free_size) {
+                 pn_link_flow(l, free_size - link_credit);
              }
             if ((app->message_count > 0) && (app->sock_sent >= app->message_count)) {
                 close_all(pn_event_connection(event), app);


### PR DESCRIPTION
The receive burst size was necessarily small (i.e. 1).  Changed the rcv burst size to reflect amount of remaining buffer.

With this change....

Total throughput goes from 127k/sec to 150k/sec with only a single generator.
With three parallel generators, total throughput is 

Rcv'd: 133692026(233783) metrics, 133692027(233783) msgs
Rcv'd: 133922123(230093) metrics, 133922123(230093) msgs

230k/sec.  

With 230k/sec there is around 1000 messages dropped per second....
