### PR TITLE
Update unit test jobs to run with ubuntu-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on: [push, pull_request]
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
ubuntu-22.04 is going end of support in June 2027

We should update our actions to use a newer Ubuntu version (ubuntu-latest/ubuntu 24.04)